### PR TITLE
SystemRequirements: C++11 no longer needed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,6 +55,5 @@ URL: https://usdaforestservice.github.io/FIESTA/,
     https://github.com/USDAForestService/FIESTA
 BugReports: https://github.com/USDAForestService/FIESTA/issues
 LazyData: true
-SystemRequirements: C++11
 Encoding: UTF-8
 RoxygenNote: 7.2.3


### PR DESCRIPTION
I don't think FIESTA needs this anyway, but in general it's no longer needed. See:
https://www.tidyverse.org/blog/2023/03/cran-checks-compiled-code/#note-regarding-systemrequirements-c11
