### PR TITLE
implementing modelselect functionality in modMAtree.R in response to it's removal from FIESTAutils/.../MAest.pbar.R

### DIFF
--- a/R/modMAtree.R
+++ b/R/modMAtree.R
@@ -648,6 +648,37 @@ modMAtree <- function(MApopdat,
 	ifelse(MAmethod == "gregEN", "gregElasticNet", 
 	ifelse(MAmethod == "ratio", "ratioEstimator", "horvitzThompson"))))
   message("generating estimates using mase::", masemethod, " function...\n")
+  
+  ## do modelselect here?
+  if (MAmethod == "greg" && modelselect == T) {
+    
+    pltlvl <- tdomdat[ , lapply(.SD, sum, na.rm = TRUE), 
+                       by=c(unitvar, cuniqueid, "TOTAL", strvar, prednames),
+                       .SDcols=response]
+    
+    y <- pltlvl[[response]]
+    xsample <- pltlvl[ , prednames, with = F, drop = F]
+    xpop <- unitlut[ , prednames, with = F, drop = F]
+    N <- sum(npixels[["npixels"]])
+    
+    preds.selected <- gregEN.select(y = y,
+                                    xsample = xsample,
+                                    xpop = xpop,
+                                    N = N,
+                                    alpha = 0.5)
+    
+    if (length(preds.selected) == 0 || is.null(preds.selected)) {
+      
+      warning("No variables selected in model selection, proceeding with all predictors listed in prednames.")
+      
+    } else {
+      
+      prednames <- preds.selected 
+      
+    }
+    
+  }
+  
   if (!MAmethod %in% c("HT", "PS")) {
     message("using the following predictors...", toString(prednames))
   }
@@ -663,37 +694,6 @@ modMAtree <- function(MApopdat,
       var_method <- "LinHTSRS"
     }
   }
-  
-  ## do modelselect here?
-  if (MAmethod == "greg" && modelselect == T) {
-    
-    pltlvl <- tdomdat[ , lapply(.SD, sum, na.rm = TRUE), 
-                       by=c(unitvar, cuniqueid, "TOTAL", strvar, prednames),
-                       .SDcols=response]
-    
-    y <- pltlvl[[response]]
-    xsample <- pltlvl[ , prednames, drop = F]
-    xpop <- unitlut[ , prednames, drop = F]
-    N <- sum(npixels[["npixels"]])
-    
-    preds.selected <- gregEN.select(y = y,
-                                    xsample = xsample,
-                                    xpop = xpop,
-                                    N = N,
-                                    alpha = 0.5)
-    
-    if (length(preds.selected) == 0 || is.null(preds.selected)) {
-      
-      warning("No variables selected in model selection, proceeding with all predictors listed in prednames.")
-      
-    } else {
-     
-      prednames <- preds.selected 
-      
-    }
-    
-  }
-  
   
   
 #  if (addtotal) {

--- a/R/modMAtree.R
+++ b/R/modMAtree.R
@@ -652,6 +652,7 @@ modMAtree <- function(MApopdat,
   ## do modelselect here?
   if (MAmethod == "greg" && modelselect == T) {
     
+    # want to do variable selection on plot level data...
     pltlvl <- tdomdat[ , lapply(.SD, sum, na.rm = TRUE), 
                        by=c(unitvar, cuniqueid, "TOTAL", strvar, prednames),
                        .SDcols=response]
@@ -669,11 +670,12 @@ modMAtree <- function(MApopdat,
     
     if (length(preds.selected) == 0 || is.null(preds.selected)) {
       
-      warning("No variables selected in model selection, proceeding with all predictors listed in prednames.")
+      warning("No variables selected in model selection, proceeding with all possible predictors. \n")
       
     } else {
       
       prednames <- preds.selected 
+      message(paste0("Predictors ", "[", paste0(prednames, collapse = ", "), "]", " were chosen in model selection.\n"))
       
     }
     

--- a/R/modMAtree.R
+++ b/R/modMAtree.R
@@ -662,8 +662,8 @@ modMAtree <- function(MApopdat,
     N <- sum(npixels[["npixels"]])
     
     preds.selected <- gregEN.select(y = y,
-                                    xsample = xsample,
-                                    xpop = xpop,
+                                    x_sample = xsample,
+                                    x_pop = xpop,
                                     N = N,
                                     alpha = 0.5)
     


### PR DESCRIPTION
The idea is to try to preserve additivity in MA estimates by doing model selection once at the very beginning instead of during each model fitting to a given rowvar and/or colvar level in the data.

I *think* that I added this code into the right section of modMAtree.R, but would appreciate a second opinion on that.