### PR TITLE
add parallelization functionality to `spExtractPoly`

### DIFF
--- a/R/spExtractPoly.R
+++ b/R/spExtractPoly.R
@@ -43,6 +43,7 @@
 #' of options. Only used when savedata = TRUE. If out_layer = NULL,
 #' default = 'polyext'.
 #' @param gui Logical. If gui, user is prompted for parameters.
+#' @param ncores Integer. Number of cores to use for extracting values. 
 #'
 #' @return \item{pltdat}{ SpatialPointsDataFrame object or data frame. Input
 #' point data with extracted raster values appended. For multi-part polygons,
@@ -113,7 +114,8 @@ spExtractPoly <- function(xyplt,
                           exportNA = FALSE, 
                           spMakeSpatial_opts = NULL,
                           savedata_opts = NULL, 
-                          gui = FALSE){
+                          gui = FALSE,
+                          ncores = NULL){
   ######################################################################################
   ## DESCRIPTION: 
   ## Extracts values from one or more polygon layers and appends to input spatial layer 
@@ -293,6 +295,27 @@ spExtractPoly <- function(xyplt,
       out_layer <- "polyext"
     }
   }
+  
+  # check ncores arg
+  if (!is.null(ncores)) {
+    if (!isNamespaceLoaded('parallel')) {
+      stop("ncores > 1 requres 'parallel' namespace.")
+    }
+    if (length(ncores) != 1) {
+      stop("ncores must be an integer vector fo length == 1")
+    } else if (!is.numeric(ncores)) {
+      stop("ncores must be a numeric value")
+    } else if (ncores > 1) {
+      nbrcores <- parallel::detectCores()
+      if (ncores > nbrcores) {
+        message("ncores is greater than number of available cores")
+        ncores <- nbrcores
+      }
+      message("Using ", nbrcores, " cores...")
+    }
+  } else {
+    ncores <- 1
+  }
  
   ########################################################################
   ### DO THE WORK
@@ -363,7 +386,34 @@ spExtractPoly <- function(xyplt,
 
     ## Extract data from polygon
     ######################################################## 
-    #spxyext <- sf::st_intersection(sppltx, polyv[, polyvars])
+    if (ncores > 1) {
+      # split-apply-combine approach
+      cl <- parallel::makeCluster(ncores)
+      parallel::clusterExport(cl, "polyv", envir = environment())
+      parallel::clusterEvalQ(cl, library(sf))
+      
+      n <- nrow(sppltx)
+      sections <- rep(1:ncores, each = ceiling(n/ncores), length.out = n)
+      sppltx_lst <- split(sppltx, f = sections)
+      
+      # st_join each section in parallel
+      # remove duplicate plots at this step too
+      st_join_lst <- parallel::parLapply(cl,
+                                         X = sppltx_lst,
+                                         fun = function(x, id) {
+                                           ext <- sf::st_join(x, polyv)
+                                           ext[!duplicated(ext[[id]]), ]
+                                         },
+                                         id = xy.uniqueid)
+      
+      spxyext <- data.table::rbindlist(st_join_lst)
+      parallel::stopCluster(cl)
+    } else {
+      spxyext <- sf::st_join(sppltx, polyv)
+      spxyext <- spxyext[!duplicated(spxyext[[xy.uniqueid]]), ]
+    }
+    
+    
     spxyext <- unique(sf::st_join(sppltx, polyv))
 
     ## Set polyvarnm

--- a/R/spExtractPoly.R
+++ b/R/spExtractPoly.R
@@ -299,10 +299,10 @@ spExtractPoly <- function(xyplt,
   # check ncores arg
   if (!is.null(ncores)) {
     if (!isNamespaceLoaded('parallel')) {
-      stop("ncores > 1 requres 'parallel' namespace.")
+      stop("ncores > 1 requires 'parallel' namespace.")
     }
     if (length(ncores) != 1) {
-      stop("ncores must be an integer vector fo length == 1")
+      stop("ncores must be an integer vector of length == 1")
     } else if (!is.numeric(ncores)) {
       stop("ncores must be a numeric value")
     } else if (ncores > 1) {

--- a/R/spExtractPoly.R
+++ b/R/spExtractPoly.R
@@ -406,7 +406,10 @@ spExtractPoly <- function(xyplt,
                                          },
                                          id = xy.uniqueid)
       
-      spxyext <- data.table::rbindlist(st_join_lst)
+      # rbindlist not perfectly compatible with sf so need to set as 
+      # data.frame and then sf class
+      spxyext_dt <- data.table::rbindlist(st_join_lst)
+      spxyext <- sf::st_as_sf(data.table::setDF(spxyext_dt))
       parallel::stopCluster(cl)
     } else {
       spxyext <- sf::st_join(sppltx, polyv)

--- a/R/spExtractPoly.R
+++ b/R/spExtractPoly.R
@@ -412,9 +412,6 @@ spExtractPoly <- function(xyplt,
       spxyext <- sf::st_join(sppltx, polyv)
       spxyext <- spxyext[!duplicated(spxyext[[xy.uniqueid]]), ]
     }
-    
-    
-    spxyext <- unique(sf::st_join(sppltx, polyv))
 
     ## Set polyvarnm
     ########################################################  

--- a/man/spExtractPoly.Rd
+++ b/man/spExtractPoly.Rd
@@ -19,7 +19,8 @@ spExtractPoly(
   exportNA = FALSE,
   spMakeSpatial_opts = NULL,
   savedata_opts = NULL,
-  gui = FALSE
+  gui = FALSE,
+  ncores = NULL
 )
 }
 \arguments{
@@ -69,6 +70,8 @@ of options. Only used when savedata = TRUE. If out_layer = NULL,
 default = 'polyext'.}
 
 \item{gui}{Logical. If gui, user is prompted for parameters.}
+
+\item{ncores}{Integer. Number of cores to use for extracting values.}
 }
 \value{
 \item{pltdat}{ SpatialPointsDataFrame object or data frame. Input


### PR DESCRIPTION
Here's a reproducible example that just shows (at least in this example) that by parallelizing we don't change anything about the actual output from the function, we just change how we get there. I should also note that since the dataset is only about 50 rows here, the parallelization method is actually a tick slower as we'd expect.

``` r
devtools::install_github("joshyam-k/FIESTA")
library(FIESTA)

WYplt <- FIESTA::WYplt

# Get polygon vector layer from FIESTA external data
WYbhdistfn <- system.file("extdata",
                          "sp_data/WYbighorn_districtbnd.shp",
                          package = "FIESTA")

# Extract points from polygon vector layer
xyext_parallel <- spExtractPoly(xyplt = WYplt,
                       polyvlst = WYbhdistfn,
                       xy.uniqueid = "CN",
                       spMakeSpatial_opts = list(xvar = "LON_PUBLIC",
                                                 yvar = "LAT_PUBLIC",
                                                 xy.crs = 4269),
                       ncores = 8)$spxyext
#> Using 8 cores...

xyext <- spExtractPoly(xyplt = WYplt,
                       polyvlst = WYbhdistfn,
                       xy.uniqueid = "CN",
                       spMakeSpatial_opts = list(xvar = "LON_PUBLIC",
                                                 yvar = "LAT_PUBLIC",
                                                 xy.crs = 4269))$spxyext


identical(xyext, xyext_parallel)
#> [1] TRUE
```