### PR TITLE
Add r-universe status badge

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -6,7 +6,8 @@ output: github_document
 [![R-CMD-check](https://github.com/USDAForestService/FIESTA/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/USDAForestService/FIESTA/actions/workflows/R-CMD-check.yaml)
 [![CRAN
 status](https://www.r-pkg.org/badges/version/FIESTA)](https://CRAN.R-project.org/package=FIESTA)
-[![cran checks](https://badges.cranchecks.info/worst/FIESTA.svg)](https://cran.r-project.org/web/checks/check_results_FIESTA.html)
+[![CRAN checks](https://badges.cranchecks.info/worst/FIESTA.svg)](https://cran.r-project.org/web/checks/check_results_FIESTA.html)
+[![r-universe status](https://usdaforestservice.r-universe.dev/badges/FIESTA)](https://usdaforestservice.r-universe.dev/FIESTA)
 <!-- badges: end -->
 
 ```{r, include = FALSE}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![R-CMD-check](https://github.com/USDAForestService/FIESTA/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/USDAForestService/FIESTA/actions/workflows/R-CMD-check.yaml)
 [![CRAN
 status](https://www.r-pkg.org/badges/version/FIESTA)](https://CRAN.R-project.org/package=FIESTA)
-[![cran checks](https://badges.cranchecks.info/worst/FIESTA.svg)](https://cran.r-project.org/web/checks/check_results_FIESTA.html)
+[![CRAN checks](https://badges.cranchecks.info/worst/FIESTA.svg)](https://cran.r-project.org/web/checks/check_results_FIESTA.html)
+[![r-universe status](https://usdaforestservice.r-universe.dev/badges/FIESTA)](https://usdaforestservice.r-universe.dev/FIESTA)
 <!-- badges: end -->
 
 <b>Authors:</b> Frescino, Tracey S.; Moisen, Gretchen G.; Patterson,


### PR DESCRIPTION
Adds an r-universe badge to README. This gives users a link to the r-universe page for FIESTA, which includes the `install.packages()` command for installing the dev version of FIESTA.